### PR TITLE
Stop adding rc0 suffix since upstream doesn't have it

### DIFF
--- a/setup_py.patch
+++ b/setup_py.patch
@@ -5,10 +5,9 @@
      twisted_deps = ['twisted']
  
 -    setup(name='thrift',
--          version='0.14.1',
--          description='Python bindings for the Apache Thrift RPC system',
 +    setup(name='thrift-unofficial',
-+          version='0.14.1rc0',
+           version='0.14.1',
+-          description='Python bindings for the Apache Thrift RPC system',
 +          description='unofficial distribution of Python bindings for the Apache Thrift RPC system',
            author='Apache Thrift Developers',
            author_email='dev@thrift.apache.org',


### PR DESCRIPTION
Since it sounds like the 0.14.1 tag is here to stay, this removes the rc0 tag from the published PyPI package to simplify version dependency version requirements.