### PR TITLE
Upgrade Twine version

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==3.1.1
+        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==4.0.2
 
     - name: Prepare package
       run: |


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
The current version of Twine fails to publish packages due to errors in
the urllib package. Twine doesn't properly define its dependency on
urllib. Upgrading Twine fixes this issue.

This was tested by running CI on this branch and putting in an invalid
password to the Pypi repo. This resulted in auth failing but previously
the request was failing to be sent at all, so auth failure indicates we
have resolved the issue.

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
